### PR TITLE
Stop using Ruby 1.8.7; Nokogiri needs >=1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 rvm:
-- 1.8.7
 - 1.9.2
 - 1.9.3


### PR DESCRIPTION
The build for my last PR broke because Nokogiri no longer works with very old Ruby versions.

https://travis-ci.org/laurilehmijoki/cf-s3-invalidator/jobs/80267320
