### PR TITLE
Update S3 bucket matching to support hypens and endpoints

### DIFF
--- a/lib/cf-s3-invalidator.rb
+++ b/lib/cf-s3-invalidator.rb
@@ -18,7 +18,7 @@ module CloudfrontS3Invalidator
         "https://cloudfront.amazonaws.com/2012-05-05/distribution/#{@distribution}",
         Net::HTTP::Get)
       matches =
-        res.body.scan(/<DomainName>([\w|\.]+)\.s3\.amazonaws\.com<\/DomainName>/)
+        res.body.scan(/<DomainName>([\w|\.|\-]+)\.s3([\w|\-]*)\.amazonaws\.com<\/DomainName>/)
       if matches.empty?
         nil
       else


### PR DESCRIPTION
If I want to point the s3 end point instead of the bucket directly in cloudfront, script doesn't recognize any matches because those are "recommended" to be in www-my-website-bucket.s3-website-us-east1.amazonaws.com. Few tweaks should be able to support it without breaking any backward compatibility.
